### PR TITLE
Update fonts to use Abril Fatface for headers and Lato for body text

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,5 @@
 // custom typefaces
-import "typeface-montserrat"
 import "typeface-merriweather"
+import "typeface-abril-fatface"
+import "typeface-lato"
 require("prismjs/themes/prism-okaidia.css")

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
     "react-typography": "^0.16.19",
+    "typeface-abril-fatface": "^0.0.72",
+    "typeface-lato": "^0.0.54",
     "typeface-merriweather": "0.0.72",
-    "typeface-montserrat": "0.0.54",
     "typography": "^0.16.19",
     "typography-theme-wordpress-2016": "^0.16.19"
   },

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -16,6 +16,7 @@ class Layout extends React.Component {
             ...scale(1.5),
             marginBottom: rhythm(1.5),
             marginTop: 0,
+            fontFamily: `Abril Fatface, Georgia, serif`
           }}
         >
           <Link
@@ -34,7 +35,7 @@ class Layout extends React.Component {
       header = (
         <h3
           style={{
-            fontFamily: `Montserrat, sans-serif`,
+            fontFamily: `Abril Fatface, Georgia, serif`,
             marginTop: 0,
           }}
         >

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -6,10 +6,14 @@ Wordpress2016.overrideThemeStyles = () => {
     "a.gatsby-resp-image-link": {
       boxShadow: `none`,
     },
+    h1: {
+      fontFamily: ["Abril Fatface", "Georgia", "serif"].join(",")
+    }
   }
 }
 
 delete Wordpress2016.googleFonts
+Wordpress2016.bodyFontFamily = ["Lato", "Arial", "sans-serif"]
 
 const typography = new Typography(Wordpress2016)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10981,15 +10981,20 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typeface-abril-fatface@^0.0.72:
+  version "0.0.72"
+  resolved "https://registry.yarnpkg.com/typeface-abril-fatface/-/typeface-abril-fatface-0.0.72.tgz#8f12b1b97e7c99617283860a97d7e2ee67f504d5"
+  integrity sha512-CaF8I80dGES7r20/bhdhRsNgvSJlbTZkcATGJxKQcl3FDMhsLXlOu0Lrk9I3BqkLXqF4O/6AeEXqI9R00k6p8g==
+
+typeface-lato@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-lato/-/typeface-lato-0.0.54.tgz#6ea56309a8b0cfdb7e8246e05de4b58b8272b47c"
+  integrity sha512-2/oP5YrXCBSLg+N2ZdWnMbJ0PRIidrJVFHgRoLxo5MNsdu9eE4aBwsoEY/K/+9rKdktGO8zpiXBYPRn9F6U/Sw==
+
 typeface-merriweather@0.0.72:
   version "0.0.72"
   resolved "https://registry.yarnpkg.com/typeface-merriweather/-/typeface-merriweather-0.0.72.tgz#2b990f5293252052d51d170c82d3892319ff0555"
   integrity sha512-gO0+fcZ1fTyKUsYY1ltYOOTI6FmBGeEdyIfeQg9NL8aInndk0feiJJVJsKHm/DiyYrnQEezraAQhz/KQoqMGtw==
-
-typeface-montserrat@0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz#3fc338db6428d73485b75aa7bd2af8c9a55b9ab3"
-  integrity sha512-Typhap0PWT299+Va0G/8ZtycHMXrH4gBWKfiW977KEBx5rXUUCa70gvqLx1fdA0WAo6bhSAQmo8uc+QFAmjPww==
 
 typography-breakpoint-constants@^0.16.19:
   version "0.16.19"


### PR DESCRIPTION
Also remove Montserrat since it's no longer used. Merriweather is still used for some headings.